### PR TITLE
Fix typo in resolve method

### DIFF
--- a/contrib/abcl-asdf/README.markdown
+++ b/contrib/abcl-asdf/README.markdown
@@ -89,7 +89,7 @@ Example 2
 Bypassing ASDF, one can directly issue requests for the Maven
 artifacts to be downloaded
 
-    CL-USER> (abcl-asdf:resolve "com.google.gwt:gwt-user")
+    CL-USER> (abcl-asdf:resolve "com.google.gwt/gwt-user")
     WARNING: Using LATEST for unspecified version.
     "/Users/evenson/.m2/repository/com/google/gwt/gwt-user/2.4.0-rc1/gwt-user-2.4.0-rc1.jar:/Users/evenson/.m2/repository/javax/validation/validation-api/1.0.0.GA/validation-api-1.0.0.GA.jar:/Users/evenson/.m2/repository/javax/validation/validation-api/1.0.0.GA/validation-api-1.0.0.GA-sources.jar"
 
@@ -100,7 +100,7 @@ ABCL-ASDF:RESOLVE does not added the resolved dependencies to the
 current JVM classpath.  Use JAVA:ADD-TO-CLASSPATH as follows to do
 that:
 
-    CL-USER> (java:add-to-classpath (abcl-asdf:as-classpath (abcl-asdf:resolve "com.google.gwt:gwt-user")))
+    CL-USER> (java:add-to-classpath (abcl-asdf:as-classpath (abcl-asdf:resolve "com.google.gwt/gwt-user")))
 
 Example 3
 ---------


### PR DESCRIPTION
Currently,

```
CL-USER(21): (abcl-asdf:resolve "com.xeiam.xchange:xchange-core")
#<THREAD "interpreter" {4E3DB38D}>: Debugger invoked on condition of type PROGRAM-ERROR
  Wrong number of arguments for #<RESOLVE-DEPENDENCIES {164FBB94}>; at least 2 expected.
```

fails, and this succeeds instead:

```
CL-USER(23): (abcl-asdf:resolve "com.xeiam.xchange/xchange-core")
WARNING: Using LATEST for unspecified version.
...
```
